### PR TITLE
Change enums back to owning their child values

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,23 +1,46 @@
-#[derive(PartialEq, Eq, Clone, Copy)]
-pub enum Term <'a>{
-    Var (&'static str),
-    Lambda {var_name: &'static str, expr: &'a Term<'a>},
-    Apply {var_term: &'a Term<'a>, function: &'a Term<'a>},
+#[derive(PartialEq, Debug)]
+pub enum Term {
+    Var(String),
+    Lambda {
+        var_name: String,
+        expr: Box<Term>,
+    },
+    Apply {
+        var_term: Box<Term>,
+        function: Box<Term>,
+    },
 
     /* Constants */
-    NumConst (u64),
-    BoolConst (bool),
+    NumConst(u64),
+    BoolConst(bool),
 
     /* Operations */
-    MathOp {opr: BinMathOp, t1: &'a Term<'a>, t2: &'a Term<'a>},
-    IfStmt {test: &'a Term<'a>, then_body: &'a Term<'a>, else_body: &'a Term<'a>},
-    Equals {left_side: &'a Term<'a>, right_side: &'a Term<'a>},
-    NotEquals {left_side: &'a Term<'a>, right_side: &'a Term<'a>},
+    MathOp {
+        opr: BinMathOp,
+        t1: Box<Term>,
+        t2: Box<Term>,
+    },
+    IfStmt {
+        test: Box<Term>,
+        then_body: Box<Term>,
+        else_body: Box<Term>,
+    },
+    Equals {
+        left_side: Box<Term>,
+        right_side: Box<Term>,
+    },
+    NotEquals {
+        left_side: Box<Term>,
+        right_side: Box<Term>,
+    },
 
-    Assignm {var_name: &'a str, expr: &'a Term<'a>},
+    Assignm {
+        var_name: String,
+        expr: Box<Term>,
+    },
 }
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Debug)]
 pub enum BinMathOp {
     Add,
     Minus,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod ast;
-mod value;
 mod type_check;
+mod value;
 //mod eval;
 
 fn main() {

--- a/src/type_check.rs
+++ b/src/type_check.rs
@@ -1,73 +1,91 @@
-
 use ast::*;
 use std::collections::HashMap;
 
-#[derive(PartialEq, Eq, Clone, Copy)]
-pub enum TermType <'a>{
+#[derive(PartialEq, Eq, Clone)]
+pub enum TermType {
     Int,
     Bool,
-    Func {name: &'a str, t1: &'a Term<'a>},
+    Func { name: String, t1: Box<TermType> },
 }
 
 /// This represents a binding between names and TermTypes.
-struct TyEnv <'a>{
-    map: HashMap <String, &'a TermType<'a>>
-}
-
-impl<'a> TyEnv<'a> {
-    fn get_val(&self, name: &str) -> Result<TermType <'a>, String> {
-            match self.map.get(name) {
-                 Some(t) => Ok(**t),
-                 _ => Err (" does not exist".to_string()),
-            }
-    }
-}
+struct TyEnv(HashMap<String, TermType>);
 
 // Main Type checking function.
 // This evaluates a term to a TermType or throw an error.
-fn type_check<'a>(term: Term<'a>, env: &'a TyEnv<'a>) -> Result<(TermType<'a>, &'a TyEnv<'a>), String> {
-    match term{
-        Term::Var(n) => Ok((env.get_val(n)?, env)),
-        Term::Lambda{var_name: v, expr: e} => Ok((TermType::Func{name: v, t1: e}, env)),
-        Term::NumConst (n) => Ok((TermType::Int, env)),
-        Term::BoolConst(b) => Ok((TermType::Bool, env)),
-        Term::MathOp {opr, t1, t2} => type_check_bin_math_op(type_check(*t1, env)?.0, type_check(*t2, env)?.0, env),
-        Term::Equals {left_side: t1, right_side: t2} => type_check_bin_logic_op (type_check(*t1, env)?.0, type_check(*t2, env)?.0, env),
-        Term::NotEquals {left_side: t1, right_side: t2} => type_check_bin_logic_op (type_check(*t1, env)?.0,type_check(*t2, env)?.0, env),
-        Term::IfStmt {test: c, then_body: tb, else_body: eb} => type_check_if (type_check(*c, env)?.0, type_check(*tb, env)?.0, type_check(*eb, env)?.0, env),
+fn type_check(term: &Term, env: &TyEnv) -> Result<TermType, String> {
+    match term {
+        Term::Var(n) => Ok(env.0
+            .get(n)
+            .ok_or("Variable name missing in environment")?
+            .clone()),
+        Term::Lambda { var_name, expr } => {
+            let mut env_prime = env.0.clone();
+            env_prime.insert(var_name.to_string(), TermType::Int);
+            Ok(TermType::Func {
+                name: var_name.clone(),
+                t1: Box::new(type_check(expr, &TyEnv(env_prime))?),
+            })
+        }
+        Term::NumConst(_) => Ok(TermType::Int),
+        Term::BoolConst(_) => Ok(TermType::Bool),
+        Term::MathOp { opr: _, t1, t2 } => {
+            type_check_bin_math_op(&type_check(t1, env)?, &type_check(t2, env)?)
+        }
+        Term::Equals {
+            left_side: t1,
+            right_side: t2,
+        } => type_check_bin_logic_op(&type_check(t1, env)?, &type_check(t2, env)?),
+        Term::NotEquals {
+            left_side: t1,
+            right_side: t2,
+        } => type_check_bin_logic_op(&type_check(t1, env)?, &type_check(t2, env)?),
+        Term::IfStmt {
+            test: c,
+            then_body: tb,
+            else_body: eb,
+        } => type_check_if(
+            &type_check(c, env)?,
+            &type_check(tb, env)?,
+            &type_check(eb, env)?,
+        ),
         _ => Err("Type checker: Invalid term".to_string()),
-   }
-}
-
-fn type_check_bin_math_op<'a>(t1: TermType, t2: TermType, env: &'a TyEnv<'a>) -> Result<(TermType<'a>, &'a TyEnv<'a>), String> {
-    match (t1, t2) {
-        (TermType::Int, TermType::Int) => Ok((TermType::Int, env)),
-        (_,_) => Err("Mathematical binary operators require both parameters to be integers".to_string()),
     }
 }
 
-fn type_check_bin_logic_op<'a>(t1: TermType, t2: TermType, env: &'a TyEnv<'a>) -> Result<(TermType<'a>, &'a TyEnv<'a>), String> {
+fn type_check_bin_math_op(t1: &TermType, t2: &TermType) -> Result<TermType, String> {
     match (t1, t2) {
-        (TermType::Int, TermType::Int) => Ok((TermType::Bool, env)),
-        (TermType::Bool, TermType::Bool) => Ok((TermType::Bool, env)),
-        (_,_) => Err("Logical binary operators require both parameters to be integers or booleans".to_string()),
+        (TermType::Int, TermType::Int) => Ok(TermType::Int),
+        (_, _) => {
+            Err("Mathematical binary operators require both parameters to be integers".to_string())
+        }
+    }
+}
+
+fn type_check_bin_logic_op(t1: &TermType, t2: &TermType) -> Result<TermType, String> {
+    match (t1, t2) {
+        (TermType::Int, TermType::Int) => Ok(TermType::Bool),
+        (TermType::Bool, TermType::Bool) => Ok(TermType::Bool),
+        (_, _) => Err(
+            "Logical binary operators require both parameters to be integers or booleans"
+                .to_string(),
+        ),
     }
 }
 
 /// Borrow checker gets thrown off from returning t1 in match_type so we need to annotate it with <'a>
-fn type_check_if<'a>(c: TermType, tb: TermType<'a>, eb: TermType, env: &'a TyEnv<'a>) -> Result<(TermType<'a>, &'a TyEnv<'a>), String> {
+fn type_check_if(c: &TermType, tb: &TermType, eb: &TermType) -> Result<TermType, String> {
     match c {
-       TermType::Bool => match_type (tb, eb, env),
-       _ => Err("Condition to if must be a boolean".to_string()),
+        TermType::Bool => match_type(tb, eb),
+        _ => Err("Condition to if must be a boolean".to_string()),
     }
 }
 
 /// Borrow checker gets thrown off from returning t1 so we need to annotate it with <'a>
-fn match_type<'a>(t1: TermType<'a>, t2: TermType, env: &'a TyEnv<'a>) -> Result<(TermType<'a>, &'a TyEnv<'a>), String> {
-    if t1 == t2{
-        Ok((t1,env))
-    }
-    else {
+fn match_type(t1: &TermType, t2: &TermType) -> Result<TermType, String> {
+    if t1 == t2 {
+        Ok(t1.clone())
+    } else {
         Err("Types do not match".to_string()) // be more descriptive. TODO: write a pretty printer for types
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,6 +1,6 @@
 /// This enum represents all possible values that a term can evaluate to.
 pub enum Value {
-    Num (u64),
-    Bool (bool),
-    Func {t1: Box<Value>, t2: Box<Value>},
+    Num(u64),
+    Bool(bool),
+    Func { t1: Box<Value>, t2: Box<Value> },
 }


### PR DESCRIPTION
This lifetime constraints on the non-owning version of the enums
looks like it would be impossible to create meaningful values
dynamically without serious acrobatics.