### PR TITLE
Add a parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
 name = "rusty-lambda"
 version = "0.1.0"
-authors = ["eschmaus <schmauss@pdx.edu>"]
+authors = ["eschmaus <schmauss@pdx.edu>", "D Scott Phillips <dsp2@pdx.edu>"]
+
+[dependencies.nom]
+version = "^4.0"
+features = ["regexp"]
 
 [dependencies]
+regex = "1"

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use value::*;
 
 /// This represents a binding between names and TermTypes.
-pub struct EvalEnv(HashMap<String, Value>);
+pub struct EvalEnv(pub HashMap<String, Value>);
 
 /// Error messages
 
@@ -18,7 +18,7 @@ static EVAL_IF_COND_REQUIRES_BOOL: &'static str = "test condition must be a bool
 /// correct. Although certain patterns would be impossible to reach after type
 /// checking, they are included for completeness... and to satisfy the rust
 /// compiler
-fn eval(node: &Term, env: &EvalEnv) -> Result<Value, String> {
+pub fn eval(node: &Term, env: &EvalEnv) -> Result<Value, String> {
     match node {
         Term::Var(n) => Ok(env
             .0

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,15 +1,16 @@
 use ast::*;
-use value::*;
 use std::collections::HashMap;
+use value::*;
 
 /// This represents a binding between names and TermTypes.
 pub struct EvalEnv(HashMap<String, Value>);
 
-
 /// Error messages
 
-static EVAL_MATH_ERROR: &'static str = "Invalid math operation. Both sides must evaluate to numbers";
-static EVAL_BOOL_ERROR: &'static str = "Both terms in equality must be of the same type. Equality on functions are not supported";
+static EVAL_MATH_ERROR: &'static str =
+    "Invalid math operation. Both sides must evaluate to numbers";
+static EVAL_BOOL_ERROR: &'static str =
+    "Both terms in equality must be of the same type. Equality on functions are not supported";
 static EVAL_INVALID_TERM: &'static str = "Invalid term";
 static EVAL_IF_COND_REQUIRES_BOOL: &'static str = "test condition must be a boolean";
 
@@ -19,58 +20,49 @@ static EVAL_IF_COND_REQUIRES_BOOL: &'static str = "test condition must be a bool
 /// compiler
 fn eval(node: &Term, env: &EvalEnv) -> Result<Value, String> {
     match node {
-        Term::Var(n) => Ok(env.0
+        Term::Var(n) => Ok(env
+            .0
             .get(n)
             .ok_or("Variable name missing in environment")?
             .clone()),
-        Term::Lambda { var_name, expr } => {
-            Ok(Value::Func {
-                name: var_name.clone(),
-                func_term: expr.clone(),
-            })
-        }
-        Term::Apply { var_term, function } => {
-            match eval(function, env)? {
-                Value::Func { name, func_term} => {
-                    let var_val = eval (var_term, env)?;
-                    let mut env_prime = env.0.clone();
-                    env_prime.insert(name.clone(), var_val);
-                    eval (&func_term, &EvalEnv(env_prime))
-                },
-                _ => Err("terms need to be applied to function types".to_string()),
+        Term::Lambda { var_name, expr } => Ok(Value::Func {
+            name: var_name.clone(),
+            func_term: expr.clone(),
+        }),
+        Term::Apply { var_term, function } => match eval(function, env)? {
+            Value::Func { name, func_term } => {
+                let var_val = eval(var_term, env)?;
+                let mut env_prime = env.0.clone();
+                env_prime.insert(name.clone(), var_val);
+                eval(&func_term, &EvalEnv(env_prime))
             }
-        }
-        Term::NumConst (n) => Ok(Value::Num (*n)),
+            _ => Err("terms need to be applied to function types".to_string()),
+        },
+        Term::NumConst(n) => Ok(Value::Num(*n)),
         Term::BoolConst(b) => Ok(Value::Bool(*b)),
-        Term::MathOp {
-            opr,
-            t1,
-            t2
-        } => eval_bin_math_op(opr, eval(t1, env)?, eval(t2, env)?),
+        Term::MathOp { opr, t1, t2 } => eval_bin_math_op(opr, eval(t1, env)?, eval(t2, env)?),
         Term::Equals {
             left_side: t1,
-            right_side: t2
-        } => eval_equals (eval(t1, env)?, eval(t2, env)?),
+            right_side: t2,
+        } => eval_equals(eval(t1, env)?, eval(t2, env)?),
         Term::NotEquals {
             left_side: t1,
-            right_side: t2
-        } => eval_not_equals (eval(t1, env)?, eval(t2, env)?),
+            right_side: t2,
+        } => eval_not_equals(eval(t1, env)?, eval(t2, env)?),
         Term::IfStmt {
             test: c,
             then_body: tb,
-            else_body: eb
-        } => eval_if (eval(c, env)?, tb, eb, env),
-        Term::Assignm { var_name, expr } => {
-            Ok(Value::Assignm {
-                name: var_name.clone(),
-                val: Box::new(eval(expr, env)?)
-            })
-        },
+            else_body: eb,
+        } => eval_if(eval(c, env)?, tb, eb, env),
+        Term::Assignm { var_name, expr } => Ok(Value::Assignm {
+            name: var_name.clone(),
+            val: Box::new(eval(expr, env)?),
+        }),
         _ => Err(EVAL_INVALID_TERM.to_string()),
     }
 }
 
-fn eval_bin_math_op (opr: &BinMathOp, t1: Value, t2: Value) -> Result<Value, String> {
+fn eval_bin_math_op(opr: &BinMathOp, t1: Value, t2: Value) -> Result<Value, String> {
     match (opr, t1, t2) {
         (BinMathOp::Add, Value::Num(v1), Value::Num(v2)) => Ok(Value::Num(v1 + v2)),
         (BinMathOp::Minus, Value::Num(v1), Value::Num(v2)) => Ok(Value::Num(v1 - v2)),
@@ -80,26 +72,31 @@ fn eval_bin_math_op (opr: &BinMathOp, t1: Value, t2: Value) -> Result<Value, Str
     }
 }
 
-fn eval_equals (t1: Value, t2: Value) -> Result<Value, String> {
+fn eval_equals(t1: Value, t2: Value) -> Result<Value, String> {
     match (t1, t2) {
-        (Value::Num(num1), Value::Num(num2)) => Ok(Value::Bool (num1 == num2)),
-        (Value::Bool(bool1), Value::Bool(bool2)) => Ok(Value::Bool (bool1 == bool2)),
-        (_,_) => Err(EVAL_BOOL_ERROR.to_string()),
+        (Value::Num(num1), Value::Num(num2)) => Ok(Value::Bool(num1 == num2)),
+        (Value::Bool(bool1), Value::Bool(bool2)) => Ok(Value::Bool(bool1 == bool2)),
+        (_, _) => Err(EVAL_BOOL_ERROR.to_string()),
     }
 }
 
-fn eval_not_equals (t1: Value, t2: Value) -> Result<Value, String> {
+fn eval_not_equals(t1: Value, t2: Value) -> Result<Value, String> {
     match (t1, t2) {
-        (Value::Num(num1), Value::Num(num2)) => Ok(Value::Bool (num1 != num2)),
-        (Value::Bool(bool1), Value::Bool(bool2)) => Ok(Value::Bool (bool1 != bool2)),
-        (_,_) => Err(EVAL_BOOL_ERROR.to_string()),
+        (Value::Num(num1), Value::Num(num2)) => Ok(Value::Bool(num1 != num2)),
+        (Value::Bool(bool1), Value::Bool(bool2)) => Ok(Value::Bool(bool1 != bool2)),
+        (_, _) => Err(EVAL_BOOL_ERROR.to_string()),
     }
 }
 
 // Evaluates if/then/else statement.
 // Note: at this point, type checking should have ensured that both branches of the condition
 // have the same type.
-fn eval_if (test: Value, then_body: &Term, else_body: &Term, env: &EvalEnv) -> Result<Value, String> {
+fn eval_if(
+    test: Value,
+    then_body: &Term,
+    else_body: &Term,
+    env: &EvalEnv,
+) -> Result<Value, String> {
     match test {
         Value::Bool(true) => eval(then_body, env),
         Value::Bool(false) => eval(else_body, env),
@@ -108,23 +105,17 @@ fn eval_if (test: Value, then_body: &Term, else_body: &Term, env: &EvalEnv) -> R
 }
 
 #[test]
-fn test_ev_const_vals(){
+fn test_ev_const_vals() {
     let ast_num = Term::NumConst(1);
     let env = EvalEnv(HashMap::new());
-    assert_eq!(
-        Ok(Value::Num(1)),
-        eval (&ast_num, &env)
-    );
+    assert_eq!(Ok(Value::Num(1)), eval(&ast_num, &env));
 
     let ast_bool = Term::BoolConst(true);
-    assert_eq!(
-        Ok(Value::Bool(true)),
-        eval (&ast_bool, &env)
-    );
+    assert_eq!(Ok(Value::Bool(true)), eval(&ast_bool, &env));
 }
 
 #[test]
-fn test_mathops(){
+fn test_mathops() {
     let add_expr = Term::MathOp {
         opr: BinMathOp::Add,
         t1: Box::new(Term::NumConst(4)),
@@ -145,46 +136,28 @@ fn test_mathops(){
         t1: Box::new(Term::NumConst(6)),
         t2: Box::new(Term::NumConst(3)),
     };
-    let incorrect_1= Term::MathOp {
+    let incorrect_1 = Term::MathOp {
         opr: BinMathOp::Divide,
         t1: Box::new(Term::BoolConst(true)),
         t2: Box::new(Term::NumConst(3)),
     };
-    let incorrect_2= Term::MathOp {
+    let incorrect_2 = Term::MathOp {
         opr: BinMathOp::Divide,
         t1: Box::new(Term::NumConst(3)),
         t2: Box::new(Term::BoolConst(true)),
     };
 
     let env = EvalEnv(HashMap::new());
-    assert_eq!(
-        Ok(Value::Num(2)),
-        eval (&sub_expr, &env)
-    );
-    assert_eq!(
-        Ok(Value::Num(10)),
-        eval (&add_expr, &env)
-    );
-    assert_eq!(
-        Ok(Value::Num(24)),
-        eval (&mul_expr, &env)
-    );
-    assert_eq!(
-        Ok(Value::Num(2)),
-        eval (&div_expr, &env)
-    );
-    assert_eq!(
-        Err(EVAL_MATH_ERROR.to_string()),
-        eval (&incorrect_1, &env)
-    );
-    assert_eq!(
-        Err(EVAL_MATH_ERROR.to_string()),
-        eval (&incorrect_2, &env)
-    );
+    assert_eq!(Ok(Value::Num(2)), eval(&sub_expr, &env));
+    assert_eq!(Ok(Value::Num(10)), eval(&add_expr, &env));
+    assert_eq!(Ok(Value::Num(24)), eval(&mul_expr, &env));
+    assert_eq!(Ok(Value::Num(2)), eval(&div_expr, &env));
+    assert_eq!(Err(EVAL_MATH_ERROR.to_string()), eval(&incorrect_1, &env));
+    assert_eq!(Err(EVAL_MATH_ERROR.to_string()), eval(&incorrect_2, &env));
 }
 
 #[test]
-fn test_boolops(){
+fn test_boolops() {
     let eq_expr_1 = Term::Equals {
         left_side: Box::new(Term::NumConst(4)),
         right_side: Box::new(Term::NumConst(6)),
@@ -206,56 +179,35 @@ fn test_boolops(){
         right_side: Box::new(Term::BoolConst(false)),
     };
     let env = EvalEnv(HashMap::new());
-    assert_eq!(
-        Ok(Value::Bool(false)),
-        eval (&eq_expr_1, &env)
-    );
-    assert_eq!(
-        Ok(Value::Bool(true)),
-        eval (&eq_expr_2, &env)
-    );
-    assert_eq!(
-        Ok(Value::Bool(false)),
-        eval (&eq_expr_3, &env)
-    );
-    assert_eq!(
-        Ok(Value::Bool(true)),
-        eval (&eq_expr_4, &env)
-    );
-    assert_eq!(
-        Err(EVAL_BOOL_ERROR.to_string()),
-        eval (&eq_expr_5, &env)
-    );
+    assert_eq!(Ok(Value::Bool(false)), eval(&eq_expr_1, &env));
+    assert_eq!(Ok(Value::Bool(true)), eval(&eq_expr_2, &env));
+    assert_eq!(Ok(Value::Bool(false)), eval(&eq_expr_3, &env));
+    assert_eq!(Ok(Value::Bool(true)), eval(&eq_expr_4, &env));
+    assert_eq!(Err(EVAL_BOOL_ERROR.to_string()), eval(&eq_expr_5, &env));
 }
 
 #[test]
-fn test_if(){
-    let if_1 = Term::IfStmt{
-            test: Box::new(Term::BoolConst(true)),
-            then_body: Box::new(Term::NumConst(6)),
-            else_body: Box::new(Term::NumConst(7)),
+fn test_if() {
+    let if_1 = Term::IfStmt {
+        test: Box::new(Term::BoolConst(true)),
+        then_body: Box::new(Term::NumConst(6)),
+        else_body: Box::new(Term::NumConst(7)),
     };
-    let if_2 = Term::IfStmt{
-            test: Box::new(Term::NumConst(1)),
-            then_body: Box::new(Term::NumConst(6)),
-            else_body: Box::new(Term::NumConst(7)),
+    let if_2 = Term::IfStmt {
+        test: Box::new(Term::NumConst(1)),
+        then_body: Box::new(Term::NumConst(6)),
+        else_body: Box::new(Term::NumConst(7)),
     };
-    let if_3 = Term::IfStmt{
-            test: Box::new(Term::BoolConst(false)),
-            then_body: Box::new(Term::NumConst(6)),
-            else_body: Box::new(Term::NumConst(7)),
+    let if_3 = Term::IfStmt {
+        test: Box::new(Term::BoolConst(false)),
+        then_body: Box::new(Term::NumConst(6)),
+        else_body: Box::new(Term::NumConst(7)),
     };
     let env = EvalEnv(HashMap::new());
-    assert_eq!(
-        Ok(Value::Num(6)),
-        eval (&if_1, &env)
-    );
+    assert_eq!(Ok(Value::Num(6)), eval(&if_1, &env));
     assert_eq!(
         Err(EVAL_IF_COND_REQUIRES_BOOL.to_string()),
-        eval (&if_2, &env)
+        eval(&if_2, &env)
     );
-    assert_eq!(
-        Ok(Value::Num(7)),
-        eval (&if_3, &env)
-    );
+    assert_eq!(Ok(Value::Num(7)), eval(&if_3, &env));
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -11,7 +11,6 @@ static EVAL_MATH_ERROR: &'static str =
     "Invalid math operation. Both sides must evaluate to numbers";
 static EVAL_BOOL_ERROR: &'static str =
     "Both terms in equality must be of the same type. Equality on functions are not supported";
-static EVAL_INVALID_TERM: &'static str = "Invalid term";
 static EVAL_IF_COND_REQUIRES_BOOL: &'static str = "test condition must be a boolean";
 
 /// Main evaluation function. This part of the code assumes that the types are
@@ -53,12 +52,11 @@ pub fn eval(node: &Term, env: &EvalEnv) -> Result<Value, String> {
             test: c,
             then_body: tb,
             else_body: eb,
-        } => eval_if(eval(c, env)?, tb, eb, env),
+        } => eval_if(&eval(c, env)?, tb, eb, env),
         Term::Assignm { var_name, expr } => Ok(Value::Assignm {
             name: var_name.clone(),
             val: Box::new(eval(expr, env)?),
         }),
-        _ => Err(EVAL_INVALID_TERM.to_string()),
     }
 }
 
@@ -92,7 +90,7 @@ fn eval_not_equals(t1: Value, t2: Value) -> Result<Value, String> {
 // Note: at this point, type checking should have ensured that both branches of the condition
 // have the same type.
 fn eval_if(
-    test: Value,
+    test: &Value,
     then_body: &Term,
     else_body: &Term,
     env: &EvalEnv,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,54 @@ mod parse;
 mod type_check;
 mod value;
 
-fn main() {
-    println!("Hello, world!");
+use eval::eval;
+use parse::parse_file;
+use std::collections::HashMap;
+use std::io;
+use type_check::type_check;
+
+fn err_str<E>(msg: E) -> io::Error
+where
+    E: Into<Box<std::error::Error + Send + Sync>>,
+{
+    io::Error::new(io::ErrorKind::InvalidInput, msg)
+}
+
+fn main() -> io::Result<()> {
+    let filename = std::env::args()
+        .nth(1)
+        .ok_or_else(|| err_str("No filename argument provided"))?;
+    let mut handle: Box<io::Read> = match filename.as_str() {
+        "-" => Box::new(std::io::stdin()),
+        _ => Box::new(std::fs::File::open(filename)?),
+    };
+    let mut contents = String::new();
+    let _len = handle.read_to_string(&mut contents)?;
+    let terms = parse_file(&contents).map_err(err_str)?;
+
+    let mut type_env = type_check::TyEnv(HashMap::new());
+    for term in &terms {
+        match term {
+            ast::Term::Assignm { var_name, expr } => {
+                let expr_type = type_check(expr, &type_env).map_err(err_str)?;
+                type_env.0.insert(var_name.to_string(), expr_type);
+            }
+            _ => {
+                type_check(term, &type_env).map_err(err_str)?;
+            }
+        };
+    }
+
+    let mut eval_env = eval::EvalEnv(HashMap::new());
+    for term in &terms {
+        let val = eval(term, &eval_env).map_err(err_str)?;
+        match val {
+            value::Value::Assignm { name, val } => {
+                eval_env.0.insert(name, *val);
+            }
+            _ => println!("{:?}", val),
+        }
+    }
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,9 @@
+#[macro_use]
+extern crate nom;
+extern crate regex;
+
 mod ast;
+mod parse;
 mod type_check;
 mod value;
 mod eval;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,10 @@ extern crate nom;
 extern crate regex;
 
 mod ast;
+mod eval;
 mod parse;
 mod type_check;
 mod value;
-mod eval;
 
 fn main() {
     println!("Hello, world!");

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -119,7 +119,9 @@ fn file(contents: &str) -> Result<Vec<Term>, &'static str> {
 #[test]
 fn test_variable() {
     use nom::{
-        Context::Code, Err::Error, ErrorKind::{Not, RegexpFind},
+        Context::Code,
+        Err::Error,
+        ErrorKind::{Not, RegexpFind},
     };
 
     assert_eq!(

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -104,13 +104,13 @@ named!(assignment<CompleteStr, Term>, ws!(do_parse!(
         _ => unreachable!(),
     }))));
 
-named!(_file<CompleteStr, Vec<Term>>, do_parse!(
+named!(_file<CompleteStr, Vec<Term>>, ws!(do_parse!(
     list: ws!(separated_list!(tag!(";"), alt!(assignment | term))) >>
     tag!(";") >>
     eof!() >>
-    (list)));
+    (list))));
 
-fn file(contents: &str) -> Result<Vec<Term>, &'static str> {
+pub fn parse_file(contents: &str) -> Result<Vec<Term>, &'static str> {
     _file(CompleteStr(contents))
         .map(|i| i.1)
         .or(Err("Parse failed"))
@@ -322,9 +322,9 @@ fn test_assignment() {
 }
 
 #[test]
-fn test_file() {
+fn test_parse_file() {
     assert_eq!(
-        file("a := 1 + 1; a;"),
+        parse_file("a := 1 + 1; a;"),
         Ok(vec![
             Assignm {
                 var_name: "a".to_string(),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,128 @@
+use ast::BinMathOp::{self, *};
+use ast::Term::{self, *};
+use nom::digit;
+use nom::types::CompleteStr;
+use std::num::ParseIntError;
+
+named!(variable<&str, Term>, do_parse!(
+    var_str: re_find!(r"^(?i:[a-z_][a-z0-9_]*)") >>
+    (Var(var_str.to_string()))));
+
+named!(number<&str, Term>, map_res!(digit, |d| {let a: Result<Term, ParseIntError> = Ok(NumConst(u64::from_str_radix(d, 10)?)); a}));
+
+named!(boolean<&str, Term>, map_res!(alt!( tag!("true") | tag!("false")),
+    |s| {let a: Result<Term, ()> = Ok(BoolConst(s == "true")); a}));
+
+named!(multiplicand<&str, Term>, do_parse!(n: number >> (n)));
+
+named!(addend<&str, Term>, do_parse!(
+    first: multiplicand >>
+    rest: many0!(tuple!(one_of!("*/"), multiplicand)) >>
+    (rest.into_iter().fold(first, |acc, (op, i)| {
+        let op = match op {
+            '*' => Multiply,
+            '/' => Divide,
+            _ => unreachable!(),
+        };
+        MathOp { opr: op, t1: Box::new(acc), t2: Box::new(i) }
+    }))));
+
+named!(term<&str, Term>, do_parse!(
+    first: addend >>
+    rest: many0!(tuple!(one_of!("+-"), addend)) >>
+    (rest.into_iter().fold(first, |acc, (op, i)| {
+        let op = match op {
+            '+' => Add,
+            '-' => Minus,
+            _ => unreachable!(),
+        };
+        MathOp { opr: op, t1: Box::new(acc), t2: Box::new(i) }
+    }))));
+
+#[test]
+fn test_variable() {
+    use nom::{Context::Code, Err::Error, ErrorKind::RegexpFind};
+
+    assert_eq!(
+        variable("_things{}"),
+        Ok(("{}", Var("_things".to_string())))
+    );
+    assert_eq!(
+        variable("_things _stuff"),
+        Ok((" _stuff", Var("_things".to_string())))
+    );
+    assert_eq!(
+        variable("1_things::/"),
+        Err(Error(Code("1_things::/", RegexpFind)))
+    );
+}
+
+#[test]
+fn test_number() {
+    use nom::{Context::Code, Err::Error, ErrorKind::Digit};
+
+    assert_eq!(number("13potato"), Ok(("potato", NumConst(13))));
+    assert_eq!(number("potato13"), Err(Error(Code("potato13", Digit))));
+}
+
+#[test]
+fn test_boolean() {
+    use nom::{Context::Code, Err::Error, ErrorKind::Alt};
+
+    assert_eq!(boolean("truefalse"), Ok(("false", BoolConst(true))));
+    assert_eq!(boolean("falsefalse"), Ok(("false", BoolConst(false))));
+    assert_eq!(boolean("falsfalse"), Err(Error(Code("falsfalse", Alt))));
+}
+
+#[test]
+fn test_term() {
+    use nom::{Context::Code, Err::Error, ErrorKind::Alt};
+
+    assert_eq!(
+        term("1+2-3;"),
+        Ok((
+            ";",
+            //     -
+            //    / \
+            //   +   3
+            //  / \
+            // 1   2
+            MathOp {
+                opr: Minus,
+                t1: Box::new(MathOp {
+                    opr: Add,
+                    t1: Box::new(NumConst(1)),
+                    t2: Box::new(NumConst(2))
+                }),
+                t2: Box::new(NumConst(3))
+            }
+        ))
+    );
+
+    assert_eq!(
+        term("1+2*3-4;"),
+        //     -
+        //    / \
+        //   +   4
+        //  / \
+        // 1   *
+        //    / \
+        //   2   3
+        Ok((
+            ";",
+            MathOp {
+                opr: Minus,
+                t1: Box::new(MathOp {
+                    opr: Add,
+                    t1: Box::new(NumConst(1)),
+                    t2: Box::new(MathOp {
+                        opr: Multiply,
+                        t1: Box::new(NumConst(2)),
+                        t2: Box::new(NumConst(3))
+                    })
+                }),
+                t2: Box::new(NumConst(4))
+            }
+        ))
+    );
+}

--- a/src/type_check.rs
+++ b/src/type_check.rs
@@ -9,11 +9,11 @@ pub enum TermType {
 }
 
 /// This represents a binding between names and TermTypes.
-pub struct TyEnv(HashMap<String, TermType>);
+pub struct TyEnv(pub HashMap<String, TermType>);
 
 // Main Type checking function.
 // This evaluates a term to a TermType or throw an error.
-fn type_check(term: &Term, env: &TyEnv) -> Result<TermType, String> {
+pub fn type_check(term: &Term, env: &TyEnv) -> Result<TermType, String> {
     match term {
         Term::Var(n) => Ok(env
             .0

--- a/src/type_check.rs
+++ b/src/type_check.rs
@@ -35,7 +35,7 @@ pub fn type_check(term: &Term, env: &TyEnv) -> Result<TermType, String> {
         },
         Term::NumConst(_) => Ok(TermType::Int),
         Term::BoolConst(_) => Ok(TermType::Bool),
-        Term::MathOp { opr: _, t1, t2 } => {
+        Term::MathOp { t1, t2, .. } => {
             type_check_bin_math_op(&type_check(t1, env)?, &type_check(t2, env)?)
         }
         Term::Equals {
@@ -55,8 +55,7 @@ pub fn type_check(term: &Term, env: &TyEnv) -> Result<TermType, String> {
             &type_check(tb, env)?,
             &type_check(eb, env)?,
         ),
-        Term::Assignm { var_name: _, expr } => type_check(expr, env),
-        _ => Err("Type checker: Invalid term".to_string()),
+        Term::Assignm { expr, .. } => type_check(expr, env),
     }
 }
 

--- a/src/type_check.rs
+++ b/src/type_check.rs
@@ -15,27 +15,24 @@ pub struct TyEnv(HashMap<String, TermType>);
 // This evaluates a term to a TermType or throw an error.
 fn type_check(term: &Term, env: &TyEnv) -> Result<TermType, String> {
     match term {
-        Term::Var(n) => Ok(env.0
+        Term::Var(n) => Ok(env
+            .0
             .get(n)
             .ok_or("Variable name missing in environment")?
             .clone()),
-        Term::Lambda { var_name, expr } => {
-            Ok(TermType::Func {
-                name: var_name.clone(),
-                func_term: expr.clone(),
-            })
-        }
-        Term::Apply { var_term, function } => {
-            match type_check(function, env)? {
-                TermType::Func{ name, func_term } => {
-                    let var_type = type_check(var_term, env)?;
-                    let mut env_prime = env.0.clone();
-                    env_prime.insert(name.clone(), var_type);
-                    type_check (&func_term, &TyEnv(env_prime))
-                },
-                _ => Err("terms need to be applied to function types".to_string()),
+        Term::Lambda { var_name, expr } => Ok(TermType::Func {
+            name: var_name.clone(),
+            func_term: expr.clone(),
+        }),
+        Term::Apply { var_term, function } => match type_check(function, env)? {
+            TermType::Func { name, func_term } => {
+                let var_type = type_check(var_term, env)?;
+                let mut env_prime = env.0.clone();
+                env_prime.insert(name.clone(), var_type);
+                type_check(&func_term, &TyEnv(env_prime))
             }
-        }
+            _ => Err("terms need to be applied to function types".to_string()),
+        },
         Term::NumConst(_) => Ok(TermType::Int),
         Term::BoolConst(_) => Ok(TermType::Bool),
         Term::MathOp { opr: _, t1, t2 } => {
@@ -98,7 +95,6 @@ fn match_type(t1: &TermType, t2: &TermType) -> Result<TermType, String> {
     }
 }
 
-
 /* Tests */
 
 #[test]
@@ -115,13 +111,12 @@ fn test_bool_const() {
     assert_eq!(Ok(TermType::Bool), type_check(&ast, &te));
 }
 
-
 #[test]
 fn test_bool_bin() {
     let te = TyEnv(HashMap::new());
-    let ast = Term::Equals{
+    let ast = Term::Equals {
         left_side: Box::new(Term::BoolConst(false)),
-        right_side: Box::new(Term::BoolConst(false))
+        right_side: Box::new(Term::BoolConst(false)),
     };
     assert_eq!(Ok(TermType::Bool), type_check(&ast, &te));
 }
@@ -131,7 +126,7 @@ fn test_bool_bin_int() {
     let te = TyEnv(HashMap::new());
     let ast = Term::Equals {
         left_side: Box::new(Term::NumConst(5)),
-        right_side: Box::new(Term::NumConst(6))
+        right_side: Box::new(Term::NumConst(6)),
     };
     assert_eq!(Ok(TermType::Bool), type_check(&ast, &te));
 }
@@ -142,7 +137,7 @@ fn test_int_bin_int() {
     let ast = Term::MathOp {
         opr: BinMathOp::Add,
         t1: Box::new(Term::NumConst(5)),
-        t2: Box::new(Term::NumConst(6))
+        t2: Box::new(Term::NumConst(6)),
     };
     assert_eq!(Ok(TermType::Int), type_check(&ast, &te));
 }
@@ -153,17 +148,15 @@ fn test_int_bin_int_nested() {
     let ast = Term::MathOp {
         opr: BinMathOp::Minus,
         t1: Box::new(Term::NumConst(5)),
-        t2: Box::new(
-            Term::MathOp {
-                opr: BinMathOp::Multiply,
-                t1: Box::new(
-                    Term::MathOp {
-                    opr: BinMathOp::Divide,
-                    t1: Box::new(Term::NumConst(24)),
-                    t2: Box::new(Term::NumConst(8)),
-                }),
+        t2: Box::new(Term::MathOp {
+            opr: BinMathOp::Multiply,
+            t1: Box::new(Term::MathOp {
+                opr: BinMathOp::Divide,
+                t1: Box::new(Term::NumConst(24)),
                 t2: Box::new(Term::NumConst(8)),
-        })
+            }),
+            t2: Box::new(Term::NumConst(8)),
+        }),
     };
     assert_eq!(Ok(TermType::Int), type_check(&ast, &te));
 }
@@ -173,12 +166,10 @@ fn test_bool_bin_nested() {
     let te = TyEnv(HashMap::new());
     let ast = Term::NotEquals {
         left_side: Box::new(Term::BoolConst(false)),
-        right_side: Box::new(
-            Term::Equals{
-                left_side: Box::new(Term::NumConst(4)),
-                right_side: Box::new(Term::NumConst(1000)),
-            },
-        )
+        right_side: Box::new(Term::Equals {
+            left_side: Box::new(Term::NumConst(4)),
+            right_side: Box::new(Term::NumConst(1000)),
+        }),
     };
     assert_eq!(Ok(TermType::Bool), type_check(&ast, &te));
 }
@@ -187,7 +178,10 @@ fn test_bool_bin_nested() {
 fn test_var_does_not_exist() {
     let te = TyEnv(HashMap::new());
     let ast = Term::Var("v1".to_string());
-    assert_eq!(Err("Variable name missing in environment".to_string()), type_check(&ast, &te));
+    assert_eq!(
+        Err("Variable name missing in environment".to_string()),
+        type_check(&ast, &te)
+    );
 }
 
 #[test]
@@ -212,7 +206,7 @@ fn if_test_2() {
     assert_eq!(
         Err("Condition to if must be a boolean".to_string()),
         type_check(&ast, &te)
-   );
+    );
 }
 
 #[test]
@@ -229,7 +223,7 @@ fn test_simple_lambda_1() {
     let math_func = Term::MathOp {
         opr: BinMathOp::Add,
         t1: Box::new(Term::Var("v1".to_string())),
-        t2: Box::new(Term::NumConst(6))
+        t2: Box::new(Term::NumConst(6)),
     };
     let math_func2 = math_func.clone();
 
@@ -245,7 +239,7 @@ fn test_simple_lambda_1() {
             func_term: Box::new(math_func2),
         }),
         type_check(&ast, &te)
-   );
+    );
 }
 
 #[test]
@@ -253,7 +247,7 @@ fn test_apply_1() {
     let math_expr = Term::MathOp {
         opr: BinMathOp::Add,
         t1: Box::new(Term::Var("v1".to_string())),
-        t2: Box::new(Term::NumConst(6))
+        t2: Box::new(Term::NumConst(6)),
     };
     let math_func = Term::Lambda {
         var_name: "v1".to_string(),
@@ -266,10 +260,7 @@ fn test_apply_1() {
         function: Box::new(math_func),
     };
 
-    assert_eq!(
-        Ok(TermType::Int),
-        type_check(&ast, &te)
-   );
+    assert_eq!(Ok(TermType::Int), type_check(&ast, &te));
 }
 
 #[test]
@@ -278,7 +269,7 @@ fn test_apply_2() {
     let math_expr = Term::MathOp {
         opr: BinMathOp::Add,
         t1: Box::new(Term::Var("v1".to_string())),
-        t2: Box::new(Term::NumConst(6))
+        t2: Box::new(Term::NumConst(6)),
     };
     let math_func = Term::Lambda {
         var_name: "v1".to_string(),
@@ -294,8 +285,5 @@ fn test_apply_2() {
         function: Box::new(math_func),
     };
 
-    assert_eq!(
-        Ok(TermType::Int),
-        type_check(&ast, &te)
-   );
+    assert_eq!(Ok(TermType::Int), type_check(&ast, &te));
 }


### PR DESCRIPTION
Adds a parser and logic in the main() function to parse, type check, eval, and print. Can be run as:

```bash
sh-3.2$ cargo run - <<EOF
> a := 1 + 2;
> a + 3;
> 4;
> EOF
```

Resulting in the output:

```
Num(6)
Num(4)
```